### PR TITLE
chore: update to version 6.3.0

### DIFF
--- a/Formula/Devcycle.rb
+++ b/Formula/Devcycle.rb
@@ -2,8 +2,8 @@ require "language/node"
 class Devcycle < Formula
   desc "Your package description"
   homepage "https://github.com/DevCycleHQ/cli"
-  url "https://registry.npmjs.org/@devcycle/cli/-/cli-6.2.2.tgz"
-  sha256 "04006fa770ffbd48e1aa07cce45070e8a0b8bbe365aa64fa95d2bfdb12125150"
+  url "https://registry.npmjs.org/@devcycle/cli/-/cli-6.3.0.tgz"
+  sha256 "d01cb09d38da99f02e5c5e8617f7cf08b0bb8e6331f9bd41e9474bf9d3fe116d"
 
   depends_on "node"
 


### PR DESCRIPTION
## Summary

- Bumps `@devcycle/cli` from `6.2.2` to `6.3.0`
- Updates tarball URL and SHA-256 checksum in `Formula/Devcycle.rb`